### PR TITLE
CAAAmomons: Banlist correction

### DIFF
--- a/mashups/official/gen8caaamomons.tour
+++ b/mashups/official/gen8caaamomons.tour
@@ -1,5 +1,5 @@
 /tour new [Gen 8] Camomons, Elimination
-/tour rules !Obtainable Abilities, -Arena Trap, -Comatose, -Contrary, -Fluffy, -Fur Coat, -Gorilla Tactics, -Huge Power, -Ice Scales, -Illusion, -Imposter, -Innards Out, -Intrepid Sword, -Libero, -Moody, -Neutralizing Gas, -Parental Bond, -Poison Heal, -Power Construct, -Protean, -Pure Power, -Shadow Tag, -Simple, -Stakeout, -Speed Boost, -Water Bubble, -Wonder Guard, -Archeops, -Blacephalon, -Cresselia, -Dragapult, -Regigigas, -Spectrier, -Urshifu +Darmanitan-Galar, 2 Ability Clause
+/tour rules !Obtainable Abilities, -Arena Trap, -Comatose, -Contrary, -Fluffy, -Fur Coat, -Gorilla Tactics, -Huge Power, -Ice Scales, -Illusion, -Imposter, -Innards Out, -Intrepid Sword, -Libero, -Moody, -Neutralizing Gas, -Parental Bond, -Poison Heal, -Power Construct, -Protean, -Pure Power, -Shadow Tag, -Simple, -Stakeout, -Speed Boost, -Water Bubble, -Wonder Guard, -Archeops, -Blacephalon, -Cresselia, -Dragapult, -Regigigas, -Spectrier, -Urshifu, +Darmanitan-Galar, 2 Ability Clause
 /tour autostart 7
 /tour autodq 4
 /tour name [Gen 8] CAAAmomons


### PR DESCRIPTION
Old banlist incorrectly banned Urshifu + Darmanitan-Galar instead of banning Urshifu and allowing Darmanitan-Galar