### PR TITLE
Change spotlight to [Gen 8] AAAlphabet Cup

### DIFF
--- a/mashups/metadata/spotlightnames.txt
+++ b/mashups/metadata/spotlightnames.txt
@@ -1,1 +1,1 @@
-[Gen 8] Mix and Mega Little Cup,[Gen 8] MnM LC
+[Gen 8] AAAlphabet Cup,[Gen 8] AAABC


### PR DESCRIPTION
The next spotlight was decided but MnM LC is scheduled to run until August 6th. This change should become effective on Monday 9th.