### PR TITLE
TSAAA: Marowak and Sneasel ban; Yveltal and Palkia unban

### DIFF
--- a/mashups/official/gen8tsaaa.tour
+++ b/mashups/official/gen8tsaaa.tour
@@ -1,5 +1,5 @@
 /tour new [Gen 8] Almost Any Ability, Elimination,,,[Gen 8] Tier Shift AAA
-/tour rules Tier Shift Mod, -Tinted Lens,-Damp Rock,-Eviolite,-Heat Rock,-Light Ball,-Absol,-Arctovish,-Bellossom,-Guzzlord,-Talonflame,+Cinderace,+Darmanitan-Galar,+Dracovish,+Genesect,+Landorus,+Magearna,+Solgaleo,+Spectrier
+/tour rules Tier Shift Mod, -Tinted Lens, -Damp Rock, -Eviolite, -Heat Rock, -Light Ball, -Absol, -Arctovish, -Bellossom, -Guzzlord, -Marowak-Base, -Sneasel, -Talonflame, +Cinderace, +Darmanitan-Galar, +Dracovish, +Genesect, +Landorus, +Magearna, +Palkia, +Solgaleo, +Spectrier, +Yveltal
 /tour autostart 7
 /tour autodq 4
 /wall **SAMPLE TEAMS: https://www.smogon.com/forums/threads/om-mashup-megathread.3657159/post-8299987**


### PR DESCRIPTION
Magpull is already banned here as it uses AAA as a base